### PR TITLE
Add environment sample and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ Thumbs.db
 .vercel
 
 # Angular environments
+# Copy `src/environments/environment.sample.ts` to `src/environments/environment.ts`
+# and populate it with your local credentials.
 src/environments/environment*.ts
 !src/environments/environment.prod.ts
 !src/environments/environment.sample.ts
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,22 @@
 # Prohub
 
-pnpm add -D tailwindcss@^3 postcss autoprefixer
-pnpm exec tailwindcss init -p
+## Getting Started
+
+1. Install dependencies
+   ```bash
+   pnpm install
+   ```
+2. Copy the sample environment file and provide your Supabase credentials
+   ```bash
+   cp src/environments/environment.sample.ts src/environments/environment.ts
+   # edit src/environments/environment.ts
+   ```
+3. Run the development server
+   ```bash
+   pnpm start
+   ```
+4. Run unit tests
+   ```bash
+   pnpm test
+   ```
+

--- a/src/environments/environment.sample.ts
+++ b/src/environments/environment.sample.ts
@@ -1,0 +1,5 @@
+export const environment = {
+  production: false,
+  supabaseUrl: '<YOUR_SUPABASE_URL>',
+  supabaseAnonKey: '<YOUR_SUPABASE_ANON_KEY>',
+};


### PR DESCRIPTION
## Summary
- add `src/environments/environment.sample.ts` with placeholders
- document installation, environment setup, dev server, and testing
- clarify `.gitignore` instructions for environment files

## Testing
- `pnpm install --ignore-scripts` *(fails: ERR_PNPM_FETCH_403)*
- `pnpm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431e62b88c8326ac524c0e2aa62097